### PR TITLE
Format code to PHPCS standards and fix some errors found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ generator.html
 js/storyjs-embed-cdn.js
 js/storyjs-embed-generator.js
 .DS_Store
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+  "name": "nuknightlab/timelinejs",
+  "description": "NU Knight Lab TimelineJS",
+  "type": "wordpress-theme",
+  "require": {
+    "pablo-sg-pacheco/wp-namespace-autoloader": "dev-master"
+  },
+  "require-dev": {
+    "automattic/vipwpcs": "^2.3",
+    "wp-coding-standards/wpcs": "^2.3",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
+    "phpcompatibility/phpcompatibility-wp": "^2.1.3"
+  },
+  "license": "GPL-2.0-or-later",
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,551 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "dee66adcf48727fbf1eccf21363f814a",
+    "packages": [
+        {
+            "name": "pablo-sg-pacheco/wp-namespace-autoloader",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pablo-sg-pacheco/wp-namespace-autoloader.git",
+                "reference": "069163f215743c83381613749ace0c5a642720b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pablo-sg-pacheco/wp-namespace-autoloader/zipball/069163f215743c83381613749ace0c5a642720b4",
+                "reference": "069163f215743c83381613749ace0c5a642720b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "cweagans/composer-patches": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
+                "phpunit/phpunit": "^7",
+                "squizlabs/php_codesniffer": "dev-master",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "patches": {
+                    "squizlabs/php_codesniffer": {
+                        "Add GitHub Actions Annotations report type": "https://github.com/squizlabs/PHP_CodeSniffer/pull/2918.patch"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pablo_Pacheco\\WP_Namespace_Autoloader\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPLv2"
+            ],
+            "authors": [
+                {
+                    "name": "Pablo dos S G Pacheco",
+                    "email": "pablo.sg.pacheco@gmail.com"
+                }
+            ],
+            "description": "A PHP autoloader class that follows the WordPress coding standards 2.0 and proposed 3.0 for class/interface/trait names and filenames",
+            "homepage": "https://github.com/pablo-pacheco/wp-namespace-autoloader",
+            "keywords": [
+                "autoload",
+                "namespace",
+                "wordpress",
+                "wp"
+            ],
+            "support": {
+                "issues": "https://github.com/pablo-sg-pacheco/wp-namespace-autoloader/issues",
+                "source": "https://github.com/pablo-sg-pacheco/wp-namespace-autoloader/tree/master"
+            },
+            "time": "2022-12-02T14:49:51+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "automattic/vipwpcs",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "php": ">=5.4",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
+                "squizlabs/php_codesniffer": "^3.5.5",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+                "source": "https://github.com/Automattic/VIP-Coding-Standards",
+                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
+            },
+            "time": "2021-09-29T16:20:23+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "time": "2022-10-25T01:46:02+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "time": "2022-10-24T09:00:36+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2023-03-31T16:46:32+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2023-02-22T23:07:41+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "pablo-sg-pacheco/wp-namespace-autoloader": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/knightlab-timeline.php
+++ b/knightlab-timeline.php
@@ -78,7 +78,7 @@ function kl_timeline_shortcode( $atts, $content = null ) {
 	if ( ! $src ) {
 		return false;
 	}
-	if ( $version == 'timeline2' ) {
+	if ( 'timeline2' === $version ) {
 		$script_path .= 'js/';
 		wp_register_script( 'kl-timeline-embed', $script_path . 'storyjs-embed.js', [ 'jquery' ], KL_TIMELINE_VERSION, true );
 	} else {

--- a/knightlab-timeline.php
+++ b/knightlab-timeline.php
@@ -86,7 +86,8 @@ function kl_timeline_shortcode( $atts, $content = null ) {
 		$script_path .= 'v3/js/';
 		wp_register_script( 'kl-timeline-embed', $script_path . 'timeline-embed.js', [ 'jquery' ], KL_TIMELINE_VERSION, true );
 	}
-	if ( $debug ) {
+
+	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 		$js_path = $script_path . 'timeline.js';
 	} else {
 		$js_path = $script_path . 'timeline-min.js';

--- a/knightlab-timeline.php
+++ b/knightlab-timeline.php
@@ -1,5 +1,11 @@
 <?php
 /**
+ * Knight Lab TimelineJS.
+ *
+ * @package knightlab/timeline
+ */
+
+/**
  * Plugin Name: Knight Lab TimelineJS
  * Plugin URI: http://timeline.knightlab.com/
  * Description: A simple shortcode to display TimelineJS.
@@ -21,17 +27,30 @@ define( 'KL_TIMELINE_URL', plugin_dir_url( __FILE__ ) );
 wp_oembed_add_provider( 'cdn.knightlab.com/libs/timeline3/*', 'https://oembed.knightlab.com/timeline/' );
 
 add_action( 'init', 'kl_timeline_scripts' );
+/**
+ * Ensure jQuery is loaded.
+ */
 function kl_timeline_scripts() {
 	wp_enqueue_script( 'jquery' );
 }
 
 add_action( 'init', 'kl_timeline_textdomain' );
+/**
+ * Set the localization text domain.
+ */
 function kl_timeline_textdomain() {
 	$plugin_dir = basename( dirname( __FILE__ ) );
 	load_plugin_textdomain( 'kl-timeline', false, $plugin_dir . '/languages/' );
 }
 
 add_shortcode( 'timeline', 'kl_timeline_shortcode' );
+/**
+ * Handle the [timeline] shortcode.
+ *
+ * @param array $atts    Array of shortcode attributes.
+ * @param int   $content  Shortcode content.
+ * @return string
+ */
 function kl_timeline_shortcode( $atts, $content = null ) {
 		extract(
 			shortcode_atts(
@@ -99,29 +118,34 @@ function kl_timeline_shortcode( $atts, $content = null ) {
 		return $shortcode;
 }
 
-/*
-	TinyMCE
-*/
-
+// TinyMCE.
 add_action( 'media_buttons_context', 'kl_timeline_tinymce_button' );
 
-// Add content for creating a timeline
+// Add content for creating a timeline.
 add_action( 'admin_footer', 'kl_timeline_tinymce' );
 
-// TinyMCE Button for the shortcode
+/**
+ * TinyMCE Button for the shortcode
+ *
+ * @param string $context Media buttons context. Default empty.
+ * @return string
+ */
 function kl_timeline_tinymce_button( $context ) {
 
 	$img          = KL_TIMELINE_URL . 'knight-diamond.png';
 	$container_id = 'add_timeline_form';
 	$title        = __( 'Insert Timeline', 'kl-timeline' );
 
-	// append the icon
+	// Append the icon.
 	$context .= "<a class='thickbox button' style='background: url({$img}) no-repeat 3px 3px; padding-left: 20px' title='{$title}' id='add_timeline'
     href='#TB_inline?width=600&height=495&inlineId={$container_id}'> Add Timeline</a>";
 
 	return $context;
 }
 
+/**
+ * Print JavaScript for the timeline.
+ */
 function kl_timeline_tinymce() {
 	?>
 <script type="text/javascript">

--- a/knightlab-timeline.php
+++ b/knightlab-timeline.php
@@ -15,7 +15,6 @@
  * License: Mozilla Public License, v. 2.0
  */
 
-
 /*
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -53,28 +52,28 @@ add_shortcode( 'timeline', 'kl_timeline_shortcode' );
  * @return string
  */
 function kl_timeline_shortcode( $atts, $content = null ) {
-		extract(
-			shortcode_atts(
-				[
-					'title'             => '',
-					'width'             => '100%',
-					'height'            => 650,
-					'font'              => '',
-					'lang'              => 'en',
-					'src'               => '',
-					'start_at_end'      => 'false',
-					'hash_bookmark'     => 'false',
-					'debug'             => 'false',
-					'maptype'           => '',
-					'start_at_slide'    => 0,
-					'start_zoom_adjust' => null,
-					'initial_zoom'      => 2,
-					'version'           => '',
-					'script_path'       => plugin_dir_url( __FILE__ ),
-				],
-				$atts
-			)
-		);
+	extract(
+		shortcode_atts(
+			[
+				'title'             => '',
+				'width'             => '100%',
+				'height'            => 650,
+				'font'              => '',
+				'lang'              => 'en',
+				'src'               => '',
+				'start_at_end'      => 'false',
+				'hash_bookmark'     => 'false',
+				'debug'             => 'false',
+				'maptype'           => '',
+				'start_at_slide'    => 0,
+				'start_zoom_adjust' => null,
+				'initial_zoom'      => 2,
+				'version'           => '',
+				'script_path'       => plugin_dir_url( __FILE__ ),
+			],
+			$atts
+		)
+	);
 
 	if ( ! $src ) {
 		return false;
@@ -92,7 +91,8 @@ function kl_timeline_shortcode( $atts, $content = null ) {
 	} else {
 		$js_path = $script_path . 'timeline-min.js';
 	}
-		$css_path = plugin_dir_url( __FILE__ ) . 'css/timeline.css';
+
+	$css_path = plugin_dir_url( __FILE__ ) . 'css/timeline.css';
 
 
 		wp_enqueue_script( 'kl-timeline-embed' );
@@ -114,9 +114,9 @@ function kl_timeline_shortcode( $atts, $content = null ) {
             lang: "' . $lang . '",
 			maptype: "' . $maptype . '",
 			script_path: "' . $script_path . '"
-        }
+		}
 // ]]></script>
-        ';
+		';
 		return $shortcode;
 }
 
@@ -140,7 +140,7 @@ function kl_timeline_tinymce_button( $context ) {
 
 	// Append the icon.
 	$context .= "<a class='thickbox button' style='background: url({$img}) no-repeat 3px 3px; padding-left: 20px' title='{$title}' id='add_timeline'
-    href='#TB_inline?width=600&height=495&inlineId={$container_id}'> Add Timeline</a>";
+	href='#TB_inline?width=600&height=495&inlineId={$container_id}'> Add Timeline</a>";
 
 	return $context;
 }

--- a/knightlab-timeline.php
+++ b/knightlab-timeline.php
@@ -170,29 +170,29 @@ function kl_timeline_tinymce() {
 		<div class="wrap">
 			<div>
 				<div style="padding:15px 15px 0 15px;">
-					<h3 style="color:#5A5A5A!important; font-family:Georgia,Times New Roman,Times,serif!important; font-size:1.8em!important; font-weight:normal!important;"><?php _e( 'Insert Timeline', 'kl-timeline' ); ?></h3>
+					<h3 style="color:#5A5A5A!important; font-family:Georgia,Times New Roman,Times,serif!important; font-size:1.8em!important; font-weight:normal!important;"><?php esc_html_e( 'Insert Timeline', 'kl-timeline' ); ?></h3>
 					<span>
-						<?php _e( 'Configurate your Timeline and add it to your post', 'kl-timeline' ); ?>
+						<?php esc_html_e( 'Configure your Timeline and add it to your post', 'kl-timeline' ); ?>
 					</span>
 				</div>
 				<div style="padding:15px 15px 0 15px;">
 					<table>
 						<tbody>
 							<tr>
-								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_data_src"><?php _e( 'Data source', 'kl-timeline' ); ?></label></td>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_data_src"><?php esc_html_e( 'Data source', 'kl-timeline' ); ?></label></td>
 								<td style="padding: 0 0 10px;"><input type="text" id="timeline_data_src" size="75" style="width:450px;"/><br/>
-									<small><a href="http://timeline.knightlab.com/" target="_blank"><?php _e( 'Learn how to create your timeline', 'kl-timeline' ); ?></a></small></td>
+									<small><a href="http://timeline.knightlab.com/" target="_blank"><?php esc_html_e( 'Learn how to create your timeline', 'kl-timeline' ); ?></a></small></td>
 							</tr>
 							<tr>
-								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_width"><?php _e( 'Width', 'kl-timeline' ); ?></label></td>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_width"><?php esc_html_e( 'Width', 'kl-timeline' ); ?></label></td>
 								<td style="padding: 0 0 10px;"><input type="text" id="timeline_width" size="5" value="100%" /></td>
 							</tr>
 							<tr>
-								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_height"><?php _e( 'Height', 'kl-timeline' ); ?></label></td>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_height"><?php esc_html_e( 'Height', 'kl-timeline' ); ?></label></td>
 								<td style="padding: 0 0 10px;"><input type="text" id="timeline_height" size="5" value="650" /></td>
 							</tr>
 							<tr>
-								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_font"><?php _e( 'Fonts', 'kl-timeline' ); ?></label></td>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_font"><?php esc_html_e( 'Fonts', 'kl-timeline' ); ?></label></td>
 								<td style="padding: 0 0 10px;">
 									<select id="timeline_font">
 										<option value="Default">PT Narrow & PT Serif</option>
@@ -218,7 +218,7 @@ function kl_timeline_tinymce() {
 								</td>
 							</tr>
 							<tr>
-								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_lang"><?php _e( 'Language', 'kl-timeline' ); ?></label></td>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_lang"><?php esc_html_e( 'Language', 'kl-timeline' ); ?></label></td>
 								<td style="padding: 0 0 10px;">
 									<select id="timeline_lang">
 									<option value="en" data-lang="English">English</option>
@@ -292,8 +292,8 @@ function kl_timeline_tinymce() {
 					</table>
 				</div>
 				<div style="padding:15px;">
-					<input type="button" class="button-primary" value="<?php _e( 'Insert Timeline', 'kl-timeline' ); ?>" onclick="insertTimeline();"/>
-					<a class="button" style="color:#bbb;" href="#" onclick="tb_remove(); return false;"><?php _e( 'Cancel', 'kl-timeline' ); ?></a>
+					<input type="button" class="button-primary" value="<?php esc_attr_e( 'Insert Timeline', 'kl-timeline' ); ?>" onclick="insertTimeline();"/>
+					<a class="button" style="color:#bbb;" href="#" onclick="tb_remove(); return false;"><?php esc_html_e( 'Cancel', 'kl-timeline' ); ?></a>
 				</div>
 			</div>
 		</div>

--- a/knightlab-timeline.php
+++ b/knightlab-timeline.php
@@ -75,9 +75,18 @@ function kl_timeline_shortcode( $atts, $content = null ) {
 		)
 	);
 
-	if ( ! $src ) {
+	if ( empty( $src ) ) {
 		return false;
 	}
+
+	if ( empty( $width ) ) {
+		$width = 0;
+	}
+
+	if ( empty( $height ) ) {
+		$height = 0;
+	}
+
 	if ( 'timeline2' === $version ) {
 		$script_path .= 'js/';
 		wp_register_script( 'kl-timeline-embed', $script_path . 'storyjs-embed.js', [ 'jquery' ], KL_TIMELINE_VERSION, true );
@@ -97,21 +106,20 @@ function kl_timeline_shortcode( $atts, $content = null ) {
 
 		wp_enqueue_script( 'kl-timeline-embed' );
 		$shortcode = '
-    <div id="timeline-embed"></div>
-    <script type="text/javascript">// <![CDATA[
-        var timeline_config = {
-            width: "' . $width . '",
-            height: "' . $height . '",
-            source: "' . $src . '",
-            embed_id: "timeline-embed",
-            start_at_end: ' . $start_at_end . ',
-            start_at_slide: "' . $start_at_slide . '",
-            start_zoom_adjust: "' . $start_zoom_adjust . '",
-            initial_zoom:"' . $initial_zoom . '",
-            hash_bookmark: ' . $hash_bookmark . ',
-            font: "' . $font . '",
-            debug: ' . $debug . ',
-            lang: "' . $lang . '",
+	<div id="timeline-embed"></div>
+	<script type="text/javascript">// <![CDATA[
+		var timeline_config = {
+			width: "' . intval( $width ) . '",
+			height: "' . intval( $height ) . '",
+			source: "' . $src . '",
+			embed_id: "timeline-embed",
+			start_at_end: ' . $start_at_end . ',
+			start_at_slide: "' . $start_at_slide . '",
+			start_zoom_adjust: "' . $start_zoom_adjust . '",
+			initial_zoom:"' . $initial_zoom . '",
+			hash_bookmark: ' . $hash_bookmark . ',
+			font: "' . $font . '",
+			lang: "' . $lang . '",
 			maptype: "' . $maptype . '",
 			script_path: "' . $script_path . '"
 		}

--- a/knightlab-timeline.php
+++ b/knightlab-timeline.php
@@ -9,7 +9,7 @@
  * Plugin Name: Knight Lab TimelineJS
  * Plugin URI: http://timeline.knightlab.com/
  * Description: A simple shortcode to display TimelineJS.
- * Version: 3.8.21.0
+ * Version: 3.8.22.0
  * Author: Knight Lab
  * Author URI: http://knightlab.northwestern.edu/
  * License: Mozilla Public License, v. 2.0

--- a/knightlab-timeline.php
+++ b/knightlab-timeline.php
@@ -23,6 +23,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
 define( 'KL_TIMELINE_URL', plugin_dir_url( __FILE__ ) );
+define( 'KL_TIMELINE_VERSION', '3.8.22.0' );
 
 wp_oembed_add_provider( 'cdn.knightlab.com/libs/timeline3/*', 'https://oembed.knightlab.com/timeline/' );
 
@@ -80,10 +81,10 @@ function kl_timeline_shortcode( $atts, $content = null ) {
 	}
 	if ( $version == 'timeline2' ) {
 		$script_path .= 'js/';
-		wp_register_script( 'kl-timeline-embed', $script_path . 'storyjs-embed.js', [ 'jquery' ], false, true );
+		wp_register_script( 'kl-timeline-embed', $script_path . 'storyjs-embed.js', [ 'jquery' ], KL_TIMELINE_VERSION, true );
 	} else {
 		$script_path .= 'v3/js/';
-		wp_register_script( 'kl-timeline-embed', $script_path . 'timeline-embed.js', [ 'jquery' ], false, true );
+		wp_register_script( 'kl-timeline-embed', $script_path . 'timeline-embed.js', [ 'jquery' ], KL_TIMELINE_VERSION, true );
 	}
 	if ( $debug ) {
 		$js_path = $script_path . 'timeline.js';

--- a/knightlab-timeline.php
+++ b/knightlab-timeline.php
@@ -16,65 +16,70 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-define( 'KL_TIMELINE_URL', plugin_dir_url(__FILE__) );
+define( 'KL_TIMELINE_URL', plugin_dir_url( __FILE__ ) );
 
 wp_oembed_add_provider( 'cdn.knightlab.com/libs/timeline3/*', 'https://oembed.knightlab.com/timeline/' );
 
-add_action('init', 'kl_timeline_scripts');
+add_action( 'init', 'kl_timeline_scripts' );
 function kl_timeline_scripts() {
-    wp_enqueue_script('jquery');
+	wp_enqueue_script( 'jquery' );
 }
 
-add_action('init', 'kl_timeline_textdomain');
+add_action( 'init', 'kl_timeline_textdomain' );
 function kl_timeline_textdomain() {
-    $plugin_dir = basename(dirname(__FILE__));
-    load_plugin_textdomain('kl-timeline', false, $plugin_dir . '/languages/');
+	$plugin_dir = basename( dirname( __FILE__ ) );
+	load_plugin_textdomain( 'kl-timeline', false, $plugin_dir . '/languages/' );
 }
 
-add_shortcode('timeline', 'kl_timeline_shortcode');
-function kl_timeline_shortcode($atts, $content=null) {
-        extract(shortcode_atts(
-                array(
-            'title' => '',
-            'width' => '100%',
-            'height' => 650,
-			'font' => '',
-            'lang' => 'en',
-            'src'=> '',
-            'start_at_end' => 'false',
-            'hash_bookmark' => 'false',
-			'debug' => 'false',
-			'maptype' => '',
-            'start_at_slide' => 0,
-			'start_zoom_adjust' => null,
-      'initial_zoom' => 2,
-			'version' => '',
-			'script_path' => plugin_dir_url( __FILE__)
-                ), $atts
-        ));
+add_shortcode( 'timeline', 'kl_timeline_shortcode' );
+function kl_timeline_shortcode( $atts, $content = null ) {
+		extract(
+			shortcode_atts(
+				[
+					'title'             => '',
+					'width'             => '100%',
+					'height'            => 650,
+					'font'              => '',
+					'lang'              => 'en',
+					'src'               => '',
+					'start_at_end'      => 'false',
+					'hash_bookmark'     => 'false',
+					'debug'             => 'false',
+					'maptype'           => '',
+					'start_at_slide'    => 0,
+					'start_zoom_adjust' => null,
+					'initial_zoom'      => 2,
+					'version'           => '',
+					'script_path'       => plugin_dir_url( __FILE__ ),
+				],
+				$atts
+			)
+		);
 
-        if(!$src) return false;
-		if($version == 'timeline2') {
-			$script_path .= 'js/';
-			wp_register_script('kl-timeline-embed', $script_path . 'storyjs-embed.js', array('jquery'), false, TRUE);
-		} else {
-			$script_path .= 'v3/js/';
-			wp_register_script('kl-timeline-embed', $script_path . 'timeline-embed.js', array('jquery'), false, TRUE);
-		}
-		if($debug) {
-			$js_path = $script_path . 'timeline.js';
-		} else {
-			$js_path = $script_path . 'timeline-min.js';
-		}
-		$css_path = plugin_dir_url( __FILE__) . 'css/timeline.css';
+	if ( ! $src ) {
+		return false;
+	}
+	if ( $version == 'timeline2' ) {
+		$script_path .= 'js/';
+		wp_register_script( 'kl-timeline-embed', $script_path . 'storyjs-embed.js', [ 'jquery' ], false, true );
+	} else {
+		$script_path .= 'v3/js/';
+		wp_register_script( 'kl-timeline-embed', $script_path . 'timeline-embed.js', [ 'jquery' ], false, true );
+	}
+	if ( $debug ) {
+		$js_path = $script_path . 'timeline.js';
+	} else {
+		$js_path = $script_path . 'timeline-min.js';
+	}
+		$css_path = plugin_dir_url( __FILE__ ) . 'css/timeline.css';
 
 
-        wp_enqueue_script('kl-timeline-embed');
-        $shortcode = '
+		wp_enqueue_script( 'kl-timeline-embed' );
+		$shortcode = '
     <div id="timeline-embed"></div>
     <script type="text/javascript">// <![CDATA[
         var timeline_config = {
-            width: "' . $width .'",
+            width: "' . $width . '",
             height: "' . $height . '",
             source: "' . $src . '",
             embed_id: "timeline-embed",
@@ -82,50 +87,50 @@ function kl_timeline_shortcode($atts, $content=null) {
             start_at_slide: "' . $start_at_slide . '",
             start_zoom_adjust: "' . $start_zoom_adjust . '",
             initial_zoom:"' . $initial_zoom . '",
-            hash_bookmark: ' . $hash_bookmark .',
+            hash_bookmark: ' . $hash_bookmark . ',
             font: "' . $font . '",
             debug: ' . $debug . ',
             lang: "' . $lang . '",
 			maptype: "' . $maptype . '",
-			script_path: "' . $script_path .'"
+			script_path: "' . $script_path . '"
         }
 // ]]></script>
         ';
-        return $shortcode;
+		return $shortcode;
 }
 
 /*
-    TinyMCE
+	TinyMCE
 */
 
-add_action('media_buttons_context', 'kl_timeline_tinymce_button');
+add_action( 'media_buttons_context', 'kl_timeline_tinymce_button' );
 
 // Add content for creating a timeline
-add_action('admin_footer', 'kl_timeline_tinymce');
+add_action( 'admin_footer', 'kl_timeline_tinymce' );
 
 // TinyMCE Button for the shortcode
-function kl_timeline_tinymce_button($context) {
+function kl_timeline_tinymce_button( $context ) {
 
-  $img = KL_TIMELINE_URL . "knight-diamond.png";
-  $container_id = 'add_timeline_form';
-  $title = __('Insert Timeline', 'kl-timeline');
+	$img          = KL_TIMELINE_URL . 'knight-diamond.png';
+	$container_id = 'add_timeline_form';
+	$title        = __( 'Insert Timeline', 'kl-timeline' );
 
-  //append the icon
-  $context .= "<a class='thickbox button' style='background: url({$img}) no-repeat 3px 3px; padding-left: 20px' title='{$title}' id='add_timeline'
+	// append the icon
+	$context .= "<a class='thickbox button' style='background: url({$img}) no-repeat 3px 3px; padding-left: 20px' title='{$title}' id='add_timeline'
     href='#TB_inline?width=600&height=495&inlineId={$container_id}'> Add Timeline</a>";
 
-  return $context;
+	return $context;
 }
 
 function kl_timeline_tinymce() {
-?>
+	?>
 <script type="text/javascript">
-        function insertTimeline(){
-            var data_src = jQuery('#timeline_data_src').val();
-            var height = jQuery('#timeline_height').val();
-            var width = jQuery('#timeline_width').val();
-            var lang = jQuery('#timeline_lang').val();
-            var font = jQuery('#timeline_font').val();
+		function insertTimeline(){
+			var data_src = jQuery('#timeline_data_src').val();
+			var height = jQuery('#timeline_height').val();
+			var width = jQuery('#timeline_width').val();
+			var lang = jQuery('#timeline_lang').val();
+			var font = jQuery('#timeline_font').val();
 			try {
 				// doesn't exist in TJS3
 				var maptype = jQuery('#timeline_maptype').val();
@@ -133,142 +138,142 @@ function kl_timeline_tinymce() {
 				console.log(e);
 			}
 
-            window.send_to_editor("[timeline src=\"" + data_src + "\" width=\"" + width + "\" height=\"" + height + "\" font=\"" + font + "\" lang=\"" + lang + "\" version=\"timeline3\" ]");
-        }
-    </script>
+			window.send_to_editor("[timeline src=\"" + data_src + "\" width=\"" + width + "\" height=\"" + height + "\" font=\"" + font + "\" lang=\"" + lang + "\" version=\"timeline3\" ]");
+		}
+	</script>
 
-    <div id="add_timeline_form" style="display:none;" class="thickbox" >
-        <div class="wrap">
-            <div>
-                <div style="padding:15px 15px 0 15px;">
-                    <h3 style="color:#5A5A5A!important; font-family:Georgia,Times New Roman,Times,serif!important; font-size:1.8em!important; font-weight:normal!important;"><?php _e('Insert Timeline', 'kl-timeline'); ?></h3>
-                    <span>
-                        <?php _e('Configurate your Timeline and add it to your post', 'kl-timeline'); ?>
-                    </span>
-                </div>
-                <div style="padding:15px 15px 0 15px;">
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_data_src"><?php _e('Data source', 'kl-timeline'); ?></label></td>
-                                <td style="padding: 0 0 10px;"><input type="text" id="timeline_data_src" size="75" style="width:450px;"/><br/>
-                                    <small><a href="http://timeline.knightlab.com/" target="_blank"><?php _e('Learn how to create your timeline', 'kl-timeline'); ?></a></small></td>
-                            </tr>
-                            <tr>
-                                <td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_width"><?php _e('Width', 'kl-timeline'); ?></label></td>
-                                <td style="padding: 0 0 10px;"><input type="text" id="timeline_width" size="5" value="100%" /></td>
-                            </tr>
-                            <tr>
-                                <td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_height"><?php _e('Height', 'kl-timeline'); ?></label></td>
-                                <td style="padding: 0 0 10px;"><input type="text" id="timeline_height" size="5" value="650" /></td>
-                            </tr>
-                            <tr>
-                                <td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_font"><?php _e('Fonts', 'kl-timeline'); ?></label></td>
-                                <td style="padding: 0 0 10px;">
-                                    <select id="timeline_font">
-                                        <option value="Default">PT Narrow & PT Serif</option>
-                                        <option value="Abril-DroidSans">Abril & Droid Sans</option>
-                                        <option value="Amatic-Andika">Amatic & Andika</option>
-                                        <option value="Bevan-PontanoSans">Bevan & Pontano Sans</option>
-                                        <option value="Bitter-Raleway">Bitter and Raleway</option>
-                                        <option value="Clicker-Garamond">Clicker and Garamond</option>
-                                        <option value="Dancing-Ledger">Dancing and Ledger</option>
-                                        <option value="Fjalla-Average">Fjalla and Average</option>
-                                        <option value="Georgia-Helvetica">Georgia and Helvetica</option>
-                                        <option value="Lustria-Lato">Lustria and Lato</option>
-                                        <option value="Medula-Lato">Medula One and Lato</option>
-                                        <option value="OldStandard">Old Standard</option>
-                                        <option value="OpenSans-GentiumBook">Open Sans and Gentium Book</option>
-                                        <option value="Playfair-FaunaOne">Playfair and Fauna One</option>
-                                        <option value="Playfair">Playfair SC and Playfair</option>
-                                        <option value="PT">PT Sans, PT Sans Narrow, and PT Serif</option>
-                                        <option value="Roboto-Megrim">Rufina and Sintony</option>
-                                        <option value="UnicaOne-Vollkorn">Unica One and Vollkorn</option>
+	<div id="add_timeline_form" style="display:none;" class="thickbox" >
+		<div class="wrap">
+			<div>
+				<div style="padding:15px 15px 0 15px;">
+					<h3 style="color:#5A5A5A!important; font-family:Georgia,Times New Roman,Times,serif!important; font-size:1.8em!important; font-weight:normal!important;"><?php _e( 'Insert Timeline', 'kl-timeline' ); ?></h3>
+					<span>
+						<?php _e( 'Configurate your Timeline and add it to your post', 'kl-timeline' ); ?>
+					</span>
+				</div>
+				<div style="padding:15px 15px 0 15px;">
+					<table>
+						<tbody>
+							<tr>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_data_src"><?php _e( 'Data source', 'kl-timeline' ); ?></label></td>
+								<td style="padding: 0 0 10px;"><input type="text" id="timeline_data_src" size="75" style="width:450px;"/><br/>
+									<small><a href="http://timeline.knightlab.com/" target="_blank"><?php _e( 'Learn how to create your timeline', 'kl-timeline' ); ?></a></small></td>
+							</tr>
+							<tr>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_width"><?php _e( 'Width', 'kl-timeline' ); ?></label></td>
+								<td style="padding: 0 0 10px;"><input type="text" id="timeline_width" size="5" value="100%" /></td>
+							</tr>
+							<tr>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_height"><?php _e( 'Height', 'kl-timeline' ); ?></label></td>
+								<td style="padding: 0 0 10px;"><input type="text" id="timeline_height" size="5" value="650" /></td>
+							</tr>
+							<tr>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_font"><?php _e( 'Fonts', 'kl-timeline' ); ?></label></td>
+								<td style="padding: 0 0 10px;">
+									<select id="timeline_font">
+										<option value="Default">PT Narrow & PT Serif</option>
+										<option value="Abril-DroidSans">Abril & Droid Sans</option>
+										<option value="Amatic-Andika">Amatic & Andika</option>
+										<option value="Bevan-PontanoSans">Bevan & Pontano Sans</option>
+										<option value="Bitter-Raleway">Bitter and Raleway</option>
+										<option value="Clicker-Garamond">Clicker and Garamond</option>
+										<option value="Dancing-Ledger">Dancing and Ledger</option>
+										<option value="Fjalla-Average">Fjalla and Average</option>
+										<option value="Georgia-Helvetica">Georgia and Helvetica</option>
+										<option value="Lustria-Lato">Lustria and Lato</option>
+										<option value="Medula-Lato">Medula One and Lato</option>
+										<option value="OldStandard">Old Standard</option>
+										<option value="OpenSans-GentiumBook">Open Sans and Gentium Book</option>
+										<option value="Playfair-FaunaOne">Playfair and Fauna One</option>
+										<option value="Playfair">Playfair SC and Playfair</option>
+										<option value="PT">PT Sans, PT Sans Narrow, and PT Serif</option>
+										<option value="Roboto-Megrim">Rufina and Sintony</option>
+										<option value="UnicaOne-Vollkorn">Unica One and Vollkorn</option>
 									</select>
 <br/>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_lang"><?php _e('Language', 'kl-timeline'); ?></label></td>
-                                <td style="padding: 0 0 10px;">
-                                    <select id="timeline_lang">
-                                    <option value="en" data-lang="English">English</option>
-                                    <option value="en-24hr" data-lang="English (24-hour time)">English (24-hour time)</option>
-                                    <option value="ar" data-lang="Arabic">العربية</option>
-                                    <option value="af" data-lang="Afrikaans">Afrikaans</option>
-                                    <option value="id" data-lang="Indonesian">Bahasa Indonesia</option>
-                                    <option value="ms" data-lang="Malay">Bahasa Melayu</option>
-                                    <option value="be" data-lang="Belarusian">Беларуская мова</option>
-                                    <option value="bg" data-lang="Bulgarian">български език</option>
-                                    <option value="ca" data-lang="Catalan">Català</option>
-                                    <option value="cz" data-lang="Czech">Čeština</option>
-                                    <option value="da" data-lang="Danish">Dansk</option>
-                                    <option value="hi" data-lang="Hindi">हिन्दी</option>
-                                    <option value="de" data-lang="German">Deutsch</option>
-                                    <option value="et" data-lang="Estonian">Eesti keel</option>
-                                    <option value="el" data-lang="Greek">ελληνικά</option>
-                                    <option value="es" data-lang="Spanish">Español</option>
-                                    <option value="eo" data-lang="Esperanto">Esperanto</option>
-                                    <option value="eu" data-lang="Basque">Euskara</option>
-                                    <option value="fo" data-lang="Faroese">Føroyskt</option>
-                                    <option value="fr" data-lang="French">Français</option>
-                                    <option value="fy" data-lang="Frisian">Frysk</option>
-                                    <option value="ga" data-lang="Irish">Gaeilge</option>
-                                    <option value="gl" data-lang="Galician">Galego</option>
-                                    <option value="ko" data-lang="Korean">한국어</option>
-                                    <option value="hr" data-lang="Croatian">Hrvatski</option>
-                                    <option value="hy" data-lang="Armenian">Հայերէն</option>
-                                    <option value="is" data-lang="Icelandic">Íslenska</option>
-                                    <option value="it" data-lang="Italian">Italiano</option>
-                                    <option value="he" data-lang="Hebrew">עברית</option>
-                                    <option value="ka" data-lang="Georgian">ქართული</option>
-                                    <option value="lv" data-lang="Latvian">Latviešu valoda</option>
-                                    <option value="lb" data-lang="Luxembourgish">Lëtzebuergesch</option>
-                                    <option value="lt" data-lang="Lithuanian">Lietuvių kalba</option>
-                                    <option value="ro" data-lang="Romanian">Limba română</option>
-                                    <option value="hu" data-lang="Hungarian">Magyar</option>
-                                    <option value="my" data-lang="Myanmar"> မြန်မာ</option>
-                                    <option value="nl" data-lang="Dutch">Nederlands</option>
-                                    <option value="ne" data-lang="Nepali">नेपाली</option>
-                                    <option value="ja" data-lang="Japanese">日本語</option>
-                                    <option value="no" data-lang="Norwegian">Norsk</option>
-                                    <option value="nb" data-lang="Norwegian - Bokmal">Norsk (bokmål)</option>
-                                    <option value="nn" data-lang="Norwegian - Nynorsk">Norsk (nynorsk)</option>
-                                    <option value="th" data-lang="Thai">ภาษาไทย</option>
-                                    <option value="pl" data-lang="Polish">Polski</option>
-                                    <option value="pt" data-lang="Portuguese">Português</option>
-                                    <option value="pt-br" data-lang="Portuguese - Brazilian">Português (Brasil)</option>
-                                    <option value="rm" data-lang="Romansh">Rumantsch</option>
-                                    <option value="ru" data-lang="Russian">Русский язык</option>
-                                    <option value="si" data-lang="Sinhalese">සිංහල</option>
-                                    <option value="sl" data-lang="Slovenian">Slovenščina</option>
-                                    <option value="sk" data-lang="Slovak">Slovenčina</option>
-                                    <option value="sr" data-lang="Serbian - Latin">Srpski</option>
-                                    <option value="sr-cy" data-lang="Serbian - Cyrillic">српски</option>
-                                    <option value="fi" data-lang="Finnish">Suomi</option>
-                                    <option value="sv" data-lang="Swedish">Svenska</option>
-                                    <option value="zh-tw" data-lang="Taiwanese">Taiwanese</option>
-                                    <option value="tl" data-lang="Tagalog">Tagalog</option>
-                                    <option value="ta" data-lang="Tamil">தமிழ்</option>
-                                    <option value="te" data-lang="Telugu">తెలుగు</option>
-                                    <option value="tr" data-lang="Turkish">Türkçe</option>
-                                    <option value="uk" data-lang="Ukrainian">Українська</option>
-                                    <option value="ur" data-lang="Urdu">اُردُو</option>
-                                    <option value="fa" data-lang="Farsi">فارسی</option>
-                                    <option value="zh-cn" data-lang="Chinese">中文</option>
+								</td>
+							</tr>
+							<tr>
+								<td valign="top" style="padding: 0 15px 5px 0;"><label for="timeline_lang"><?php _e( 'Language', 'kl-timeline' ); ?></label></td>
+								<td style="padding: 0 0 10px;">
+									<select id="timeline_lang">
+									<option value="en" data-lang="English">English</option>
+									<option value="en-24hr" data-lang="English (24-hour time)">English (24-hour time)</option>
+									<option value="ar" data-lang="Arabic">العربية</option>
+									<option value="af" data-lang="Afrikaans">Afrikaans</option>
+									<option value="id" data-lang="Indonesian">Bahasa Indonesia</option>
+									<option value="ms" data-lang="Malay">Bahasa Melayu</option>
+									<option value="be" data-lang="Belarusian">Беларуская мова</option>
+									<option value="bg" data-lang="Bulgarian">български език</option>
+									<option value="ca" data-lang="Catalan">Català</option>
+									<option value="cz" data-lang="Czech">Čeština</option>
+									<option value="da" data-lang="Danish">Dansk</option>
+									<option value="hi" data-lang="Hindi">हिन्दी</option>
+									<option value="de" data-lang="German">Deutsch</option>
+									<option value="et" data-lang="Estonian">Eesti keel</option>
+									<option value="el" data-lang="Greek">ελληνικά</option>
+									<option value="es" data-lang="Spanish">Español</option>
+									<option value="eo" data-lang="Esperanto">Esperanto</option>
+									<option value="eu" data-lang="Basque">Euskara</option>
+									<option value="fo" data-lang="Faroese">Føroyskt</option>
+									<option value="fr" data-lang="French">Français</option>
+									<option value="fy" data-lang="Frisian">Frysk</option>
+									<option value="ga" data-lang="Irish">Gaeilge</option>
+									<option value="gl" data-lang="Galician">Galego</option>
+									<option value="ko" data-lang="Korean">한국어</option>
+									<option value="hr" data-lang="Croatian">Hrvatski</option>
+									<option value="hy" data-lang="Armenian">Հայերէն</option>
+									<option value="is" data-lang="Icelandic">Íslenska</option>
+									<option value="it" data-lang="Italian">Italiano</option>
+									<option value="he" data-lang="Hebrew">עברית</option>
+									<option value="ka" data-lang="Georgian">ქართული</option>
+									<option value="lv" data-lang="Latvian">Latviešu valoda</option>
+									<option value="lb" data-lang="Luxembourgish">Lëtzebuergesch</option>
+									<option value="lt" data-lang="Lithuanian">Lietuvių kalba</option>
+									<option value="ro" data-lang="Romanian">Limba română</option>
+									<option value="hu" data-lang="Hungarian">Magyar</option>
+									<option value="my" data-lang="Myanmar"> မြန်မာ</option>
+									<option value="nl" data-lang="Dutch">Nederlands</option>
+									<option value="ne" data-lang="Nepali">नेपाली</option>
+									<option value="ja" data-lang="Japanese">日本語</option>
+									<option value="no" data-lang="Norwegian">Norsk</option>
+									<option value="nb" data-lang="Norwegian - Bokmal">Norsk (bokmål)</option>
+									<option value="nn" data-lang="Norwegian - Nynorsk">Norsk (nynorsk)</option>
+									<option value="th" data-lang="Thai">ภาษาไทย</option>
+									<option value="pl" data-lang="Polish">Polski</option>
+									<option value="pt" data-lang="Portuguese">Português</option>
+									<option value="pt-br" data-lang="Portuguese - Brazilian">Português (Brasil)</option>
+									<option value="rm" data-lang="Romansh">Rumantsch</option>
+									<option value="ru" data-lang="Russian">Русский язык</option>
+									<option value="si" data-lang="Sinhalese">සිංහල</option>
+									<option value="sl" data-lang="Slovenian">Slovenščina</option>
+									<option value="sk" data-lang="Slovak">Slovenčina</option>
+									<option value="sr" data-lang="Serbian - Latin">Srpski</option>
+									<option value="sr-cy" data-lang="Serbian - Cyrillic">српски</option>
+									<option value="fi" data-lang="Finnish">Suomi</option>
+									<option value="sv" data-lang="Swedish">Svenska</option>
+									<option value="zh-tw" data-lang="Taiwanese">Taiwanese</option>
+									<option value="tl" data-lang="Tagalog">Tagalog</option>
+									<option value="ta" data-lang="Tamil">தமிழ்</option>
+									<option value="te" data-lang="Telugu">తెలుగు</option>
+									<option value="tr" data-lang="Turkish">Türkçe</option>
+									<option value="uk" data-lang="Ukrainian">Українська</option>
+									<option value="ur" data-lang="Urdu">اُردُو</option>
+									<option value="fa" data-lang="Farsi">فارسی</option>
+									<option value="zh-cn" data-lang="Chinese">中文</option>
 									</select><br/>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div style="padding:15px;">
-                    <input type="button" class="button-primary" value="<?php _e('Insert Timeline', 'kl-timeline'); ?>" onclick="insertTimeline();"/>
-                    <a class="button" style="color:#bbb;" href="#" onclick="tb_remove(); return false;"><?php _e('Cancel', 'kl-timeline'); ?></a>
-                </div>
-            </div>
-        </div>
-    </div>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div style="padding:15px;">
+					<input type="button" class="button-primary" value="<?php _e( 'Insert Timeline', 'kl-timeline' ); ?>" onclick="insertTimeline();"/>
+					<a class="button" style="color:#bbb;" href="#" onclick="tb_remove(); return false;"><?php _e( 'Cancel', 'kl-timeline' ); ?></a>
+				</div>
+			</div>
+		</div>
+	</div>
 
-    <?php
+	<?php
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards">
+	<description>Generally-applicable sniffs for WordPress plugins</description>
+
+	<rule ref="WordPress-Extra" />
+	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress-VIP-Go" />
+
+	<rule ref="WordPress">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
+	</rule>
+
+	<rule ref="WordPressVIPMinimum">
+		<exclude name="WordPressVIPMinimum.Classes.RestrictedExtendClasses.wp_cli" />
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.get_page_by_title_get_page_by_title" />
+	</rule>
+
+	<!-- extra for rules -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+	<arg name="colors" />
+	<arg value="s" />
+	<arg name="basepath" value="."/>
+	<arg name="parallel" value="50"/>
+	<arg name="severity" value="1"/>
+	<!-- /extra -->
+
+	<arg name="extensions" value="php"/>
+	<!-- Show sniff codes in all reports -->
+	<arg value="s" />
+
+	<!-- Allow invoking just `phpcs` on command line without assuming STDIN for file input. -->
+	<file>.</file>
+
+	<exclude-pattern>*/dev-lib/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
+	<exclude-pattern>*/cmb2/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
### Description
Format plugin code to PHPCS standards.

Fixes these errors:
* missing and incorrect comments
* unescaped output
* missing version number
* incorrect equality check

### Formatting/linting
run `composer install` once and `./vendor/bin/phpcf`to format and `./vendor/bin/phpcs` to lint.